### PR TITLE
Favicon url returns 404

### DIFF
--- a/src/components/atoms/ExtraMetaTags.astro
+++ b/src/components/atoms/ExtraMetaTags.astro
@@ -2,6 +2,6 @@
 import { SITE } from '~/config.mjs';
 ---
 
-<link rel="shortcut icon" href={`${SITE.basePathname}favicon.ico`} />
-<link rel="icon" type="image/svg+xml" href={`${SITE.basePathname}favicon.svg`} />
-<link rel="mask-icon" href={`${SITE.basePathname}favicon.svg`} color="#8D46E7" />
+<link rel="shortcut icon" href={`${SITE.basePathname}/favicon.ico`} />
+<link rel="icon" type="image/svg+xml" href={`${SITE.basePathname}/favicon.svg`} />
+<link rel="mask-icon" href={`${SITE.basePathname}/favicon.svg`} color="#8D46E7" />


### PR DESCRIPTION
When I set `basePathname` in the configuration file, the app cannot find the favicon.

Example:
```javascript
export const SITE = {
	name: 'AstroWind',

	origin: 'https://example.com',
	basePathname: '/mypath',
	trailingSlash: false,

	title: 'AstroWind — Your website with Astro + Tailwind CSS',
	description: '🚀 AstroWind is a free and ready to start template to make your website using Astro and Tailwind CSS.',

	googleAnalyticsId: false,
	googleSiteVerificationId: 'false',
};
```

The favicon URL generated is wrong: `https://example.com/mypathfavicon.png`.
The right one is `https://example.com/mypath/favicon.png`.