### PR TITLE
Add missing required alt property for GetImageTransform

### DIFF
--- a/src/components/core/MetaTags.astro
+++ b/src/components/core/MetaTags.astro
@@ -13,6 +13,7 @@ import SplitbeeAnalytics from './SplitbeeAnalytics.astro';
 
 const { src: defaultImage } = await getImage({
 	src: defaultImageSrc,
+	alt: 'Default image',
 	width: 1200,
 	height: 628,
 });


### PR DESCRIPTION
Solves this TS error;

```
(alias) const defaultImageSrc: string
import defaultImageSrc
Argument of type '{ src: string; width: number; height: number; }' is not assignable to parameter of type 'GetImageTransform'.
  Property 'alt' is missing in type '{ src: string; width: number; height: number; }' but required in type 'GetImageTransform'.ts(2345)
```

in file `src/components/core/MetaTags.astro` on line 14:18