### PR TITLE
Update import statement for Icon from 'astro-icon'

### DIFF
--- a/src/components/blog/ListItem.astro
+++ b/src/components/blog/ListItem.astro
@@ -1,5 +1,5 @@
 ---
-import Icon from 'astro-icon';
+import { Icon } from 'astro-icon';
 import { Picture } from '@astrojs/image/components';
 import PostTags from '~/components/blog/Tags.astro';
 

--- a/src/components/blog/SinglePost.astro
+++ b/src/components/blog/SinglePost.astro
@@ -1,5 +1,5 @@
 ---
-import Icon from 'astro-icon';
+import { Icon } from 'astro-icon';
 import { Picture } from '@astrojs/image/components';
 
 import PostTags from '~/components/blog/Tags.astro';

--- a/src/components/widgets/Content.astro
+++ b/src/components/widgets/Content.astro
@@ -1,5 +1,5 @@
 ---
-import Icon from 'astro-icon';
+import { Icon } from 'astro-icon';
 import { Picture } from '@astrojs/image/components';
 
 interface Item {


### PR DESCRIPTION
I've noticed that the following import statement:

```ts
import Icon from 'astro-icon';
```

Is used in the following files:

- [src/components/widgets/Content.astro#L2](https://github.com/onwidget/astrowind/blob/main/src/components/widgets/Content.astro#L2)
- [src/components/blog/ListItem.astro#L2](https://github.com/onwidget/astrowind/blob/main/src/components/blog/ListItem.astro#L2)
- [src/components/blog/SinglePost.astro#L2](https://github.com/onwidget/astrowind/blob/main/src/components/blog/SinglePost.astro#L2)

I suggest changing the import statement to:

```diff ts
- import Icon from 'astro-icon';
+ import { Icon } from 'astro-icon';
```

I have confirmed in my local environment that it works fine after the change!
If my approach is incorrect, please let me know.
