### PR TITLE
Use non-breaking space

### DIFF
--- a/src/components/widgets/Hero.astro
+++ b/src/components/widgets/Hero.astro
@@ -52,7 +52,7 @@ const {
                     <a class="btn btn-primary sm:mb-0 w-full" href={callToAction?.href} target="_blank" rel="noopener">
                       {callToAction?.icon && (
                         <>
-                          <Icon name={callToAction.icon} class="w-5 h-5 mr-1 -ml-1.5" />{' '}
+                          <Icon name={callToAction.icon} class="w-5 h-5 mr-1 -ml-1.5" />&nbsp;
                         </>
                       )}
                       {callToAction?.text}
@@ -70,7 +70,7 @@ const {
                     <a class="btn w-full" href={callToAction2?.href}>
                       {callToAction2?.icon && (
                         <>
-                          <Icon name={callToAction2.icon} class="w-5 h-5 mr-1 -ml-1.5" />{' '}
+                          <Icon name={callToAction2.icon} class="w-5 h-5 mr-1 -ml-1.5" />&nbsp;
                         </>
                       )}
                       {callToAction2.text}


### PR DESCRIPTION
In some cases during development or after building, "{' '}" appears. It's better to use the HTML entity &nbsp; instead.