### PR TITLE
Inherit button hover color from CustomStyles

### DIFF
--- a/src/assets/styles/base.css
+++ b/src/assets/styles/base.css
@@ -29,7 +29,7 @@
   }
 
   .btn-primary {
-    @apply font-semibold bg-primary text-white border-primary hover:bg-blue-900 hover:border-blue-900 hover:text-white dark:text-white dark:bg-primary dark:border-primary dark:hover:border-blue-900 dark:hover:bg-blue-900;
+    @apply font-semibold bg-primary text-white border-primary hover:bg-secondary hover:border-secondary hover:text-white dark:text-white dark:bg-primary dark:border-primary dark:hover:border-secondary dark:hover:bg-secondary;
   }
 }
 


### PR DESCRIPTION
This is small fix to make `.btn-primary` CSS class inherit hover color from `--aw-color-secondary` defined in `CustomStyles.astro` as I believe is the intention.