### PR TITLE
add astro type for Post["Content"]

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import { AstroComponentFactory } from 'astro/dist/runtime/server';
+
 export interface Post {
   id: string;
   slug: string;
@@ -18,7 +20,7 @@ export interface Post {
   tags?: Array<string>;
   author?: string;
 
-  Content: unknown;
+  Content: AstroComponentFactory;
   content?: string;
 
   readingTime?: number;


### PR DESCRIPTION
Currently if you use this template as-is, you might get following TS error
![Code_QbiBrq22gq](https://user-images.githubusercontent.com/23616925/226604813-f4b26551-344b-4da4-80eb-b8527310101d.png)

`@ts-ignore` is not working in this case.

I looked up at `getEntryBySlug()` [API](https://docs.astro.build/en/reference/api-reference/#getentrybyslug) and thought it would make sense to use built-in util by Astro 2.