### PR TITLE
fix(package.json): change sharp version to comply with astro

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "prettier": "^2.8.7",
     "prettier-plugin-astro": "^0.8.0",
     "reading-time": "^1.5.0",
-    "sharp": "^0.32.0",
+    "sharp": "^0.31.3",
     "svgo": "2.8.0",
     "tailwindcss": "^3.3.1",
     "typescript": "^5.0.4"


### PR DESCRIPTION
Closes #162 

## 📝 Description

Sets sharp package version to ^0.31.3, as required by Astro ^2.3.0 as peerDepedency

-Breaking change: no breaking change.

## ⛳️ Current behavior (updates)

Currently, version is set to ^0.32.0 that throws an error with npm and a warning with pnpm.

## 🚀 New behavior

Will just work.

## 💣 Is this a breaking change (Yes/No):

No

![Screenshot from 2023-04-28 11-20-05](https://user-images.githubusercontent.com/100282637/235120460-3092bd04-eea1-4521-876b-e3dc73c9e103.png)
