### PR TITLE
Adding Sitemap to the Meta info

### DIFF
--- a/src/components/common/MetaTags.astro
+++ b/src/components/common/MetaTags.astro
@@ -95,3 +95,4 @@ const image =
 <link rel="shortcut icon" href={getAsset('/favicon.ico')} />
 <link rel="icon" type="image/svg+xml" href={getAsset('/favicon.svg')} />
 <link rel="mask-icon" href={getAsset('/favicon.svg')} color="#8D46E7" />
+<link rel="sitemap" href="/sitemap-index.xml"/>


### PR DESCRIPTION
It will help improve the SEO score of websites.

P.S. - It is also a good idea to add it to the robots.txt, but we can't use relative paths there.