### PR TITLE
✨ [feature] Add 'findTags' and 'findCategories' methods to blog.ts

### DIFF
--- a/src/utils/blog.ts
+++ b/src/utils/blog.ts
@@ -122,3 +122,28 @@ export const findLatestPosts = async ({ count }: { count?: number }): Promise<Ar
 
   return posts ? posts.slice(0, _count) : [];
 };
+
+/** */
+export const findTags = async (): Promise<Array<string>> => {
+  const posts = await fetchPosts();
+  const tags = posts.reduce((acc, post: Post) => {
+    if (post.tags && Array.isArray(post.tags)) {
+      return [...acc, ...post.tags];
+    }
+    return acc;
+  }, []);
+  return [...new Set(tags)];
+};
+
+/** */
+export const findCategories = async (): Promise<Array<string>> => {
+  const posts = await fetchPosts();
+  const categories = posts.reduce((acc, post: Post) => {
+    if (post.category) {
+      return [...acc, post.category];
+    }
+    return acc;
+  }, []);
+  return [...new Set(categories)];
+};
+


### PR DESCRIPTION
I've added the `findTags` and `findCategories` methods to blog.ts

The `findTags` method is designed to retrieve all the tags associated with posts, while the `findCategories` method offers a way to fetch all the categories assigned to posts.

These methods return categories and tags as a Set to ensure that the resulting array contains only unique values. You can see an example usage of these methods in the implementation of a sample user interface provided at the end of the page [here](https://ladunjexa.vercel.app/blog)

attached image:
![img](https://i.ibb.co/MPx0R5L/screenshot-ladunjexa-vercel-app-2023-06-09-06-54-52.png)

Please note that in addition to this pull request, I will create two additional pull requests that implement these methods as shown above. I will code them as code comments to prevent them from being seen in the deployment.