### PR TITLE
🎨 [enhancement] Add code to display tags & categories in the main blog page

### DIFF
--- a/src/pages/[...blog]/[...page].astro
+++ b/src/pages/[...blog]/[...page].astro
@@ -43,7 +43,7 @@ const meta = {
     <BlogList posts={page.data} />
     <Pagination prevUrl={page.url.prev} nextUrl={page.url.next} />
     <!--
-      <PostTags tags={allCategories} class="mb-2" header="Search by Categories:" />
+      <PostTags tags={allCategories} class="mb-2" header="Search by Categories:" isCategory />
       <PostTags tags={allTags}  header="Search by Tags:" />
     -->
   </section>

--- a/src/pages/[...blog]/[...page].astro
+++ b/src/pages/[...blog]/[...page].astro
@@ -5,8 +5,10 @@ import Layout from '~/layouts/PageLayout.astro';
 import BlogList from '~/components/blog/List.astro';
 import Headline from '~/components/blog/Headline.astro';
 import Pagination from '~/components/blog/Pagination.astro';
+// import PostTags from "~/components/blog/Tags.astro";
 
 import { fetchPosts } from '~/utils/blog';
+// import { findTags, findCategories } from '~/utils/blog';
 import { BLOG_BASE } from '~/utils/permalinks';
 
 export async function getStaticPaths({ paginate }) {
@@ -19,6 +21,9 @@ export async function getStaticPaths({ paginate }) {
 
 const { page } = Astro.props;
 const currentPage = page.currentPage ?? 1;
+
+// const allCategories = await findCategories();
+// const allTags = await findTags();
 
 const meta = {
   title: `Blog${currentPage > 1 ? ` — Page ${currentPage}` : ''}`,
@@ -37,5 +42,9 @@ const meta = {
     </Headline>
     <BlogList posts={page.data} />
     <Pagination prevUrl={page.url.prev} nextUrl={page.url.next} />
+    <!--
+      <PostTags tags={allCategories} class="mb-2" header="Search by Categories:" />
+      <PostTags tags={allTags}  header="Search by Tags:" />
+    -->
   </section>
 </Layout>


### PR DESCRIPTION
As a direct continuation of these requests, #175 & #176 
I've added to this code as comments a implementation of methods mentioned in the pull requests, in order to display a list of tags and categories.

Since in the current implementation of the `Tags.astro` method, the reference is only to tags, the ` PostTags` statement for the categories will result in a URL address of "tag/{slug}". 😅 I must admit that I initially overlooked this, but we could either create an additional .astro file for categories (similar to tags, using the 'category' permalink), or add an optional parameter (e.g., a boolean) to determine whether it is a tag or a category.

Here's an example of how you could implement it:
```typescript
export interface Props {
   ...
   isCategory?: boolean;
}

const { ..., isCategory = false} = Astro.props;

// href attribute of a element in li element.
href={getPermalink(tag, isCategory? ('category') : ('tag'))}
```
```typescript
<PostTags tags={allCategories} class="mb-2" header="Search by Categories:" isCategory />
```

If you're interested in pursuing this approach, I would be more than happy to do so. Please let me know your preferred method or if there's another way you'd like it to be implemented.

In any case, it is possible to merge this PR because the added code is fully commented, which prevents the comments from being visible in the deployment.
 
**Update:**
I edited my pull-requests comments and added the way of determine if it's category or tag I wrote above.
The methods, implementation and enhancements are correct and work perfectly as shown in the picture below:
![img](https://i.ibb.co/MPx0R5L/screenshot-ladunjexa-vercel-app-2023-06-09-06-54-52.png)