### PR TITLE
Include some widgets in about-us page

### DIFF
--- a/src/components/widgets/Features3.astro
+++ b/src/components/widgets/Features3.astro
@@ -12,6 +12,8 @@ const {
   image,
   items = [],
   columns,
+  isBeforeContent,
+  isAfterContent,
 
   id,
   isDark = false,
@@ -20,7 +22,14 @@ const {
 } = Astro.props as Features;
 ---
 
-<WidgetWrapper id={id} isDark={isDark} containerClass={classes?.container} bg={bg}>
+<WidgetWrapper
+  id={id}
+  isDark={isDark}
+  containerClass={`${isBeforeContent ? 'md:pb-8 lg:pb-12' : ''} ${isAfterContent ? 'pt-0 md:pt-0 lg:pt-0' : ''} ${
+    classes?.container ?? ''
+  }`}
+  bg={bg}
+>
   <Headline title={title} subtitle={subtitle} tagline={tagline} classes={classes?.headline} />
 
   <div aria-hidden="true" class="aspect-w-16 aspect-h-7">
@@ -48,7 +57,7 @@ const {
     items={items}
     columns={columns}
     classes={{
-      container: 'mt-5 lg:mt-16',
+      container: 'mt-12',
       panel: 'max-w-full sm:max-w-md',
       title: 'text-lg font-semibold',
       icon: 'flex-shrink-0 mt-1 text-primary w-6 h-6',

--- a/src/components/widgets/Hero.astro
+++ b/src/components/widgets/Hero.astro
@@ -1,16 +1,6 @@
 ---
 import { Icon } from 'astro-icon/components';
 import { Picture } from '@astrojs/image/components';
-import { CallToAction } from '~/types';
-
-export interface Props {
-  title?: string;
-  subtitle?: string;
-  content?: string;
-  callToAction?: string | CallToAction;
-  callToAction2?: string | CallToAction;
-  image?: string | any; // TODO: find HTMLElementProps
-}
 
 const {
   title = await Astro.slots.render('title'),

--- a/src/components/widgets/Steps2.astro
+++ b/src/components/widgets/Steps2.astro
@@ -1,20 +1,8 @@
 ---
 import { Icon } from 'astro-icon/components';
-import { CallToAction } from '~/types';
-
-interface Item {
-  title: string;
-  description: string;
-  icon?: string;
-}
-
-export interface Props {
-  title?: string;
-  subtitle?: string;
-  tagline?: string;
-  callToAction?: string | CallToAction;
-  items: Array<Item>;
-}
+import Headline from '../ui/Headline.astro';
+import { Steps } from '~/types';
+import WidgetWrapper from '../ui/WidgetWrapper.astro';
 
 const {
   title = await Astro.slots.render('title'),
@@ -22,101 +10,68 @@ const {
   tagline,
   callToAction = await Astro.slots.render('callToAction'),
   items = [],
-} = Astro.props;
+  isReversed = false,
 
-/**
- * 
-	
-<!-- Steps2 Widget Example ***************** -->
-
-<Steps2
-	title="Sed ac magna sit amet risus tristique interdum, at vel velit in hac habitasse platea dictumst."
-	subtitle="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi sagittis, quam nec venenatis lobortis, mi risus tempus nulla, sed porttitor est nibh at nulla. Praesent placerat enim ut ex tincidunt vehicula. Fusce sit amet dui tellus."
-	callToAction={{
-		text: 'Get template',
-		href: 'https://github.com/onwidget/astrowind',
-		icon: 'tabler:download',
-	}}
-	items={[
-		{
-			title: 'Responsive Elements',
-			description:
-				'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi sagittis, quam nec venenatis lobortis, mi risus tempus nulla.',
-		},
-		{
-			title: 'Flexible Team',
-			description:
-				'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi sagittis, quam nec venenatis lobortis, mi risus tempus nulla.',
-		},
-		{
-			title: 'Ecologic Software',
-			description:
-				'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi sagittis, quam nec venenatis lobortis, mi risus tempus nulla.',
-		},
-	]}
-/>
- */
+  id,
+  isDark = false,
+  classes = {},
+  bg = await Astro.slots.render('bg'),
+} = Astro.props as Steps;
 ---
 
-<section>
-  <div class="max-w-7xl mx-auto px-4 sm:px-6 overflow-hidden not-prose">
-    <div class="py-12 md:py-20">
-      <div class="py-4 sm:py-6 lg:py-8">
-        <div class="flex flex-wrap md:-mx-8">
-          <div class="w-full lg:w-1/2 px-0 sm:px-8 mb-12">
-            <div>
-              {
-                tagline && (
-                  <p
-                    class="text-base text-primary dark:text-blue-200 font-semibold tracking-wide uppercase"
-                    set:html={tagline}
-                  />
-                )
-              }
-              {title && <h2 class="mb-4 text-3xl lg:text-4xl font-bold font-heading" set:html={title} />}
-              {subtitle && <p class="mb-8 text-xl text-muted dark:text-slate-400" set:html={subtitle} />}
+<WidgetWrapper id={id} isDark={isDark} containerClass={`max-w-screen-xl mx-auto ${classes?.container ?? ''}`} bg={bg}>
+  <div class={`flex flex-col gap-8 md:gap-12 md:flex-row ${isReversed ? 'md:flex-row-reverse' : ''}`}>
+    <div class={`w-full lg:w-1/2 gap-8 md:gap-12 ${isReversed ? 'lg:ml-16 md:ml-8 ml-0' : 'lg:mr-16 md:mr-8 mr-0'}`}>
+      <Headline
+        title={title}
+        subtitle={subtitle}
+        tagline={tagline}
+        callToAction={callToAction}
+        classes={{
+          container: 'text-left mb-4 md:mb-8',
+          title: 'mb-4 text-3xl lg:text-4xl font-bold font-heading',
+          subtitle: 'mb-8 text-xl text-muted dark:text-slate-400',
+          // ...((classes?.headline as {}) ?? {}),
+        }}
+      />
 
-              <div class="w-full">
-                {
-                  typeof callToAction === 'string' ? (
-                    <Fragment set:html={callToAction} />
-                  ) : (
-                    callToAction &&
-                    callToAction.text &&
-                    callToAction.href && (
-                      <a class="btn btn-primary mb-4 sm:mb-0" href={callToAction.href} target="_blank" rel="noopener">
-                        {callToAction.icon && <Icon name={callToAction.icon} class="w-5 h-5 mr-1 -ml-1.5" />}
-                        {callToAction.text}
-                      </a>
-                    )
-                  )
-                }
-              </div>
-            </div>
-          </div>
-          <div class="w-full lg:w-1/2 px-0 sm:px-8">
-            <ul class="space-y-10">
-              {
-                items && items.length
-                  ? items.map(({ title: title2, description, icon }, index) => (
-                      <li class="flex md:-mx-4">
-                        <div class="pr-4 sm:pl-4">
-                          <span class="flex w-16 h-16 mx-auto items-center justify-center text-2xl font-bold rounded-full bg-blue-100 text-primary">
-                            {icon ? <Icon name={icon} class="w-6 h-6 icon-bold" /> : index + 1}
-                          </span>
-                        </div>
-                        <div class="pl-4">
-                          <h3 class="mb-4 text-xl font-semibold font-heading" set:html={title2} />
-                          <p class="text-muted dark:text-gray-400" set:html={description} />
-                        </div>
-                      </li>
-                    ))
-                  : ''
-              }
-            </ul>
-          </div>
-        </div>
+      <div class="w-full">
+        {
+          typeof callToAction === 'string' ? (
+            <Fragment set:html={callToAction} />
+          ) : (
+            callToAction &&
+            callToAction.text &&
+            callToAction.href && (
+              <a class="btn btn-primary mb-12" href={callToAction.href} target="_blank" rel="noopener">
+                {callToAction.icon && <Icon name={callToAction.icon} class="w-5 h-5 mr-1 -ml-1.5" />}
+                {callToAction.text}
+              </a>
+            )
+          )
+        }
       </div>
     </div>
+    <div class="w-full lg:w-1/2 px-8 sm:px-0">
+      <ul class="space-y-10">
+        {
+          items && items.length
+            ? items.map(({ title: title2, description, icon }, index) => (
+                <li class="flex md:-mx-4">
+                  <div class="pr-4 sm:pl-4">
+                    <span class="flex w-16 h-16 mx-auto items-center justify-center text-2xl font-bold rounded-full bg-blue-100 text-primary">
+                      {icon ? <Icon name={icon} class="w-6 h-6 icon-bold" /> : index + 1}
+                    </span>
+                  </div>
+                  <div class="pl-4">
+                    <h3 class="mb-4 text-xl font-semibold font-heading" set:html={title2} />
+                    <p class="text-muted dark:text-gray-400" set:html={description} />
+                  </div>
+                </li>
+              ))
+            : ''
+        }
+      </ul>
+    </div>
   </div>
-</section>
+</WidgetWrapper>

--- a/src/components/widgets/Steps2.astro
+++ b/src/components/widgets/Steps2.astro
@@ -1,6 +1,6 @@
 ---
 import { Icon } from 'astro-icon/components';
-import type { CallToAction } from '~/components/widgets/CallToAction.astro';
+import { CallToAction } from '~/types';
 
 interface Item {
   title: string;

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -119,8 +119,37 @@ const metadata = {
   <!-- Steps2 Widget ****************** -->
 
   <Steps2
+    title="Our values"
+    subtitle="Maecenas eu tellus eget est scelerisque lacinia et a diam. Aliquam velit lorem, vehicula id fermentum et, rhoncus et purus. Nulla facilisi. Vestibulum malesuada lacus id nibh posuere feugiat."
+    items={[
+      {
+        title: 'Customer-centric approach',
+        description:
+          'Donec id nibh neque. Quisque et fermentum tortor. Fusce vitae dolor a mauris dignissim commodo. Ut eleifend luctus condimentum.',
+      },
+      {
+        title: 'Constant Improvement',
+        description:
+          'Phasellus laoreet fermentum venenatis. Vivamus dapibus pulvinar arcu eget mattis. Fusce eget mauris leo.',
+      },
+      {
+        title: 'Ethical Practices',
+        description:
+          'Vestibulum imperdiet libero et lectus molestie, et maximus augue porta. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.',
+      },
+    ]}
+  />
+
+  <!-- Steps2 Widget ****************** -->
+
+  <Steps2
     title="Achievements"
     subtitle="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi sagittis, quam nec venenatis lobortis, mi risus tempus nulla, sed porttitor est nibh at nulla. Praesent placerat enim ut ex tincidunt vehicula. Fusce sit amet dui tellus."
+    isReversed={true}
+    callToAction={{
+      text: 'See more',
+      href: '/',
+    }}
     items={[
       {
         title: 'Global reach',
@@ -138,12 +167,6 @@ const metadata = {
         description:
           'Phasellus lacinia cursus velit, eu malesuada magna pretium eu. Etiam aliquet tellus purus, blandit lobortis ex rhoncus vitae.',
         icon: 'tabler:award',
-      },
-      {
-        title: 'Market leadership',
-        description:
-          'Aliquam sem orci, varius pharetra tortor vel, ultricies elementum augue. Vestibulum ante ipsum primis in faucibus.',
-        icon: 'tabler:trophy',
       },
     ]}
   />

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,11 +1,194 @@
 ---
+import Features2 from '~/components/widgets/Features2.astro';
+import Features3 from '~/components/widgets/Features3.astro';
+import Hero from '~/components/widgets/Hero.astro';
+import Stats from '~/components/widgets/Stats.astro';
+import Steps2 from '~/components/widgets/Steps2.astro';
 import Layout from '~/layouts/PageLayout.astro';
 
 const metadata = {
-  title: "About us",
+  title: 'About us',
 };
 ---
 
 <Layout metadata={metadata}>
-  About us
+  <!-- Hero Widget ******************* -->
+
+  <Hero image={{ src: import('~/assets/images/caos.jpg'), alt: 'Caos Image' }}>
+    <Fragment slot="title">
+      Elevate your online presence with our <br />
+      <span class="text-accent dark:text-white highlight"> Beautiful Website Templates</span>
+    </Fragment>
+
+    <Fragment slot="subtitle">
+      Donec efficitur, ipsum quis congue luctus, mauris magna convallis mauris, eu auctor nisi lectus non augue. Donec
+      quis lorem non massa vulputate efficitur ac at turpis. Sed tincidunt ex a nunc convallis, et lobortis nisi tempus.
+      Suspendisse vitae nisi eget tortor luctus maximus sed non lectus.
+    </Fragment>
+  </Hero>
+
+  <!-- Stats Widget ****************** -->
+
+  <Stats
+    stats={[
+      { title: 'Offices', amount: '4' },
+      { title: 'Employees', amount: '248' },
+      { title: 'Templates', amount: '12' },
+      { title: 'Awards', amount: '24' },
+    ]}
+  />
+
+  <!-- Features3 Widget ************** -->
+
+  <Features3
+    title="Our templates"
+    subtitle="Etiam scelerisque, enim eget vestibulum luctus, nibh mauris blandit nulla, nec vestibulum risus justo ut enim. Praesent lacinia diam et ante imperdiet euismod."
+    columns={3}
+    items={[
+      {
+        title: 'Educational',
+        description:
+          'Morbi faucibus luctus quam, sit amet aliquet felis tempor id. Cras augue massa, ornare quis dignissim a, molestie vel nulla.',
+        icon: 'tabler:template',
+      },
+      {
+        title: 'Interior Design',
+        description:
+          'Vivamus porttitor, tortor convallis aliquam pretium, turpis enim consectetur elit, vitae egestas purus erat ac nunc nulla.',
+        icon: 'tabler:template',
+      },
+      {
+        title: 'Photography',
+        description:
+          'Duis sed lectus in nisl vehicula porttitor eget quis odio. Aliquam erat volutpat. Nulla eleifend nulla id sem fermentum.',
+        icon: 'tabler:template',
+      },
+    ]}
+  />
+
+  <!-- Features3 Widget ************** -->
+
+  <Features3
+    columns={3}
+    items={[
+      {
+        title: 'E-commerce',
+        description:
+          'Rutrum non odio at vehicula. Proin ipsum justo, dignissim in vehicula sit amet, dignissim id quam. Sed ac tincidunt sapien.',
+        icon: 'tabler:template',
+      },
+      {
+        title: 'Blog',
+        description:
+          'Nullam efficitur volutpat sem sed fringilla. Suspendisse et enim eu orci volutpat laoreet ac vitae libero.',
+        icon: 'tabler:template',
+      },
+      {
+        title: 'Business',
+        description:
+          'Morbi et elit finibus, facilisis justo ut, pharetra ipsum. Donec efficitur, ipsum quis congue luctus, mauris magna.',
+        icon: 'tabler:template',
+      },
+      {
+        title: 'Branding',
+        description:
+          'Suspendisse vitae nisi eget tortor luctus maximus sed non lectus. Cras malesuada pretium placerat. Nullam venenatis dolor a ante rhoncus.',
+        icon: 'tabler:template',
+      },
+      {
+        title: 'Medical',
+        description:
+          'Vestibulum malesuada lacus id nibh posuere feugiat. Nam volutpat nulla a felis ultrices, id suscipit mauris congue. In hac habitasse platea dictumst.',
+        icon: 'tabler:template',
+      },
+      {
+        title: 'Fashion Design',
+        description:
+          'Maecenas eu tellus eget est scelerisque lacinia et a diam. Aliquam velit lorem, vehicula id fermentum et, rhoncus et purus.',
+        icon: 'tabler:template',
+      },
+    ]}
+    image={{
+      src: import('~/assets/images/colors.jpg'),
+      alt: 'Colorful Image',
+    }}
+  />
+
+  <!-- Steps2 Widget ****************** -->
+
+  <Steps2
+    title="Achievements"
+    subtitle="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi sagittis, quam nec venenatis lobortis, mi risus tempus nulla, sed porttitor est nibh at nulla. Praesent placerat enim ut ex tincidunt vehicula. Fusce sit amet dui tellus."
+    items={[
+      {
+        title: 'Global reach',
+        description: 'Nam malesuada urna in enim imperdiet tincidunt. Phasellus non tincidunt nisi, at elementum mi.',
+        icon: 'tabler:globe',
+      },
+      {
+        title: 'Positive customer feedback and reviews',
+        description:
+          'Cras semper nulla leo, eget laoreet erat cursus sed. Praesent faucibus massa in purus iaculis dictum.',
+        icon: 'tabler:message-star',
+      },
+      {
+        title: 'Awards and recognition as industry experts',
+        description:
+          'Phasellus lacinia cursus velit, eu malesuada magna pretium eu. Etiam aliquet tellus purus, blandit lobortis ex rhoncus vitae.',
+        icon: 'tabler:award',
+      },
+      {
+        title: 'Market leadership',
+        description:
+          'Aliquam sem orci, varius pharetra tortor vel, ultricies elementum augue. Vestibulum ante ipsum primis in faucibus.',
+        icon: 'tabler:trophy',
+      },
+    ]}
+  />
+
+  <!-- Features2 Widget ************** -->
+
+  <Features2
+    tagline="Our locations"
+    columns={4}
+    items={[
+      {
+        title: 'EE.UU',
+        description: '1234 Lorem Ipsum St, 12345, Miami',
+      },
+      {
+        title: 'Spain',
+        description: '5678 Lorem Ipsum St, 56789, Madrid',
+      },
+      {
+        title: 'Australia',
+        description: '9012 Lorem Ipsum St, 90123, Sydney',
+      },
+      {
+        title: 'Brazil',
+        description: '3456 Lorem Ipsum St, 34567, São Paulo',
+      },
+    ]}
+  />
+
+  <!-- Features2 Widget ************** -->
+
+  <Features2
+    tagline="Technical Support"
+    columns={2}
+    items={[
+      {
+        title: 'Chat with us',
+        description:
+          'Integer luctus laoreet libero, auctor varius purus rutrum sit amet. Ut nec molestie nisi, quis eleifend mi.',
+        icon: 'tabler:messages',
+      },
+      {
+        title: 'Call us',
+        description:
+          'Mauris faucibus finibus orci, in posuere elit viverra non. In hac habitasse platea dictumst. Cras lobortis metus a hendrerit congue.',
+        icon: 'tabler:headset',
+      },
+    ]}
+  />
 </Layout>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -44,6 +44,7 @@ const metadata = {
     title="Our templates"
     subtitle="Etiam scelerisque, enim eget vestibulum luctus, nibh mauris blandit nulla, nec vestibulum risus justo ut enim. Praesent lacinia diam et ante imperdiet euismod."
     columns={3}
+    isBeforeContent={true}
     items={[
       {
         title: 'Educational',
@@ -70,6 +71,7 @@ const metadata = {
 
   <Features3
     columns={3}
+    isAfterContent={true}
     items={[
       {
         title: 'E-commerce',

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -215,6 +215,8 @@ export interface Features extends Headline, Widget {
   callToAction1?: CallToAction;
   callToAction2?: CallToAction;
   isReversed?: boolean;
+  isBeforeContent?: boolean;
+  isAfterContent?: boolean;
 }
 
 export interface Faqs extends Headline, Widget {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -178,7 +178,8 @@ export interface Collapse {
 
 // WIDGETS
 export interface Hero extends Headline, Widget {
-  image?: Image;
+  content?: string;
+  image?: string | unknown;
   callToAction1?: CallToAction;
   callToAction2?: CallToAction;
   isReversed?: boolean;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -233,6 +233,7 @@ export interface Steps extends Headline, Widget {
     icon?: string;
     classes?: Record<string, string>;
   }>;
+  callToAction?: string | CallToAction;
   image?: string | Image;
   isReversed?: boolean;
 }


### PR DESCRIPTION
Widgets included:
- One Hero
- One Stats
- Two Features3
- One Steps2
- Two Features2

- Modify Features3 when they are consecutive (include isBeforeContent and isAfterContent)
- Add WidgetWrapper y Headline in Steps2 widget
- Include isReversed in Steps2 widget