### PR TITLE
Fixes AstroCompress settings

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -64,13 +64,10 @@ export default defineConfig({
     tasks(),
 
     compress({
-      CSS: true,
       HTML: {
         removeAttributeQuotes: false,
       },
       Image: false,
-      JavaScript: true,
-      SVG: true,
       Logger: 1,
     }),
   ],

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -64,15 +64,14 @@ export default defineConfig({
     tasks(),
 
     compress({
-      css: true,
-      html: {
+      CSS: true,
+      HTML: {
         removeAttributeQuotes: false,
       },
-      img: false,
-      js: true,
-      svg: true,
-
-      logger: 1,
+      Image: false,
+      JavaScript: true,
+      SVG: true,
+      Logger: 1,
     }),
   ],
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -64,10 +64,13 @@ export default defineConfig({
     tasks(),
 
     compress({
+      CSS: true,
       HTML: {
         removeAttributeQuotes: false,
       },
       Image: false,
+      JavaScript: true,
+      SVG: true,
       Logger: 1,
     }),
   ],


### PR DESCRIPTION
This fixes the `AstroCompress` settings as they were pascal cased in the later version. Also, you don't need `JavaScript: true`, `CSS: true` and `SVG: true`. If `true` the option will always default to their original value.