### PR TITLE
Add Related Blog Posts Component

### DIFF
--- a/src/components/blog/RelatedPosts.astro
+++ b/src/components/blog/RelatedPosts.astro
@@ -1,0 +1,28 @@
+---
+import { APP_BLOG } from "~/utils/config";
+
+import { fetchPosts, getRelatedPosts } from "~/utils/blog";
+import BlogHighlightedPosts from "../widgets/BlogHighlightedPosts.astro";
+import type { Post } from "~/types";
+import { getBlogPermalink } from "~/utils/permalinks";
+
+export interface Props {
+  post: Post;
+}
+
+const { post } = Astro.props;
+const fetchedPosts = await fetchPosts();
+const relatedPosts = post.tags ? getRelatedPosts(fetchedPosts, post.slug, post.tags) : [];
+---
+
+{
+  APP_BLOG.isRelatedPostsEnabled ? (
+    <BlogHighlightedPosts
+      classes={{ container: "pt-0 lg:pt-0 md:pt-0" }}
+      title="Related Posts"
+      linkText="View All Posts"
+      linkUrl={getBlogPermalink()}
+      postIds={relatedPosts.map((post) => post.id)}
+    />
+  ) : null
+}

--- a/src/config.yaml
+++ b/src/config.yaml
@@ -35,6 +35,8 @@ apps:
   blog:
     isEnabled: true
     postsPerPage: 6
+    isRelatedPostsEnabled: true
+    relatedPostsCount: 4
 
     post:
       isEnabled: true

--- a/src/pages/[...blog]/index.astro
+++ b/src/pages/[...blog]/index.astro
@@ -11,6 +11,7 @@ import { getCanonical, getPermalink } from '~/utils/permalinks';
 import { getStaticPathsBlogPost, blogPostRobots } from '~/utils/blog';
 import { findImage } from '~/utils/images';
 import type { MetaData } from '~/types';
+import RelatedPosts from '~/components/blog/RelatedPosts.astro';
 
 export const prerender = true;
 
@@ -45,4 +46,5 @@ const metadata = merge(
 <Layout metadata={metadata}>
   <SinglePost post={{ ...post, image: image }} url={url} />
   <ToBlogLink />
+  <RelatedPosts post={post} />
 </Layout>

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -25,6 +25,8 @@ export interface I18NConfig {
 export interface AppBlogConfig {
   isEnabled: boolean;
   postsPerPage: number;
+  isRelatedPostsEnabled: boolean;
+  relatedPostsCount: number;
   post: {
     isEnabled: boolean;
     permalink: string;


### PR DESCRIPTION
One of the features I wanted was an ability to generated a handful of related posts at the bottom of my blog articles (and found a few other people looking for it too).

The basic function is to grab all the blog posts, filter by tag, and then randomly sort them. Afterwards, if there aren't enough posts to fill the grid, then it just takes any additional posts in random order.

I added a setting to the config to easily disable this and adjust the number of posts. Since I am reusing the BlogHighlightedPosts component, 4 is the logical default.

Few questions to the maintainers (assuming you like the idea):

1. Should I disable it by default?
2. Does it need gutters like the blog posts?
3. Do you want me to make an example page where it shows up regardless of the overall config?

Appreciate all your work, hope I can give back a little.