### PR TITLE
Check for property existance for GetImageResult.

### DIFF
--- a/src/utils/images.ts
+++ b/src/utils/images.ts
@@ -79,9 +79,9 @@ export const adaptOpenGraphImages = async (
 
         if (typeof _image === 'object') {
           return {
-            url: typeof _image.src === 'string' ? String(new URL(_image.src, astroSite)) : 'pepe',
-            width: typeof _image.width === 'number' ? _image.width : undefined,
-            height: typeof _image.height === 'number' ? _image.height : undefined,
+            url: 'src' in _image && typeof _image.src === 'string' ? String(new URL(_image.src, astroSite)) : 'pepe',
+            width: 'width' in _image && typeof _image.width === 'number' ? _image.width : undefined,
+            height: 'height' in _image && typeof _image.height === 'number' ? _image.height : undefined,
           };
         }
         return {


### PR DESCRIPTION
Fix npm run build fails due to getImage() return type GetImageResult #364

*********

This issue happens when you are running "astro check".
With the original commands you posted this is not a visible error and will not cause any issues.
However, seems like cloudfront deployment pipeline (might be others as well) is running this command which caused a failure with the deployment process.

_NB_ There is also requirement to install astro/check plugin and the js-yaml package.

Have not added them on this specific PR to avoid too many changes.
Will be happy to add them and submit another PR if this is fine by you :)