### PR TITLE
Title: Fix TypeScript Error TS7016 for js-yaml Import

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "@iconify-json/flat-color-icons": "^1.1.10",
         "@iconify-json/tabler": "^1.1.105",
         "@tailwindcss/typography": "^0.5.10",
+        "@types/js-yaml": "^4.0.9",
         "@types/lodash.merge": "^4.6.9",
         "@typescript-eslint/eslint-plugin": "^7.0.1",
         "@typescript-eslint/parser": "^7.0.1",
@@ -2251,6 +2252,12 @@
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-7.0.2.tgz",
       "integrity": "sha512-mm2HqV22l8lFQh4r2oSsOEVea+m0qqxEmwpc9kC1p/XzmjLWrReR9D/GRs8Pex2NX/imyEH9c5IU/7tMBQCHOA==",
+      "dev": true
+    },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
       "dev": true
     },
     "node_modules/@types/json-schema": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@iconify-json/flat-color-icons": "^1.1.10",
     "@iconify-json/tabler": "^1.1.105",
     "@tailwindcss/typography": "^0.5.10",
+    "@types/js-yaml": "^4.0.9",
     "@types/lodash.merge": "^4.6.9",
     "@typescript-eslint/eslint-plugin": "^7.0.1",
     "@typescript-eslint/parser": "^7.0.1",


### PR DESCRIPTION
This pull request fixes TypeScript error TS7016 that occurs when importing the js-yaml module within src/utils/config.ts. The error indicates that TypeScript could not find a declaration file for the js-yaml module, resulting in an implicit 'any' type for the module import. To fix this, I added it to package.json.