### PR TITLE
Removes `typescript-esbuild`

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "astro-icon": "^1.1.0",
     "limax": "4.1.0",
     "lodash.merge": "^4.6.2",
-    "typescript-esbuild": "^0.4.9",
     "unpic": "^3.18.0"
   },
   "devDependencies": {


### PR DESCRIPTION
`typescript-esbuild` was used in earlier versions of `astro-compress`, but you don't need it now. It's bundled internally and only used in development as a `devDependency`. Using it as a `dependency` in `package.json` would only create overhead and install all of these dependencies:

```json
"dependencies": {
	"@types/node": "20.12.2",
	"commander": "12.0.0",
	"deepmerge-ts": "5.1.0",
	"esbuild": "0.20.2",
	"esbuild-plugin-copy": "2.1.1",
	"fast-glob": "3.3.2",
	"typescript": "5.4.3"
},
"devDependencies": {
	"ts-node": "10.9.2"
},
"peerDependencies": {
	"@playform/document": "0.0.2"
},
```