### PR TITLE
Fix header 1px gap

### DIFF
--- a/src/components/widgets/Announcement.astro
+++ b/src/components/widgets/Announcement.astro
@@ -2,7 +2,7 @@
 ---
 
 <div
-  class="dark text-muted text-sm bg-black dark:bg-transparent dark:border-b dark:border-slate-800 dark:text-slate-400 hidden md:block overflow-hidden px-3 py-2 relative text-ellipsis whitespace-nowrap"
+  class="dark text-muted text-sm bg-black dark:bg-transparent dark:border-b dark:border-slate-800 dark:text-slate-400 hidden md:flex gap-1 overflow-hidden px-3 py-2 relative text-ellipsis whitespace-nowrap"
 >
   <span class="dark:bg-slate-700 bg-white/40 dark:text-slate-300 font-semibold px-1 py-0.5 text-xs mr-0.5 rtl:mr-0 rtl:ml-0.5 inline-block">NEW</span>
   <a href="https://astro.build/blog/astro-450/" class="text-muted hover:underline dark:text-slate-400 font-medium"
@@ -11,7 +11,7 @@
   <a
     target="_blank"
     rel="noopener"
-    class="float-right rtl:float-left"
+    class="ltr:ml-auto rtl:mr-auto"
     title="If you like AstroWind, give us a star."
     href="https://github.com/onwidget/astrowind"
   >


### PR DESCRIPTION
Changed the "Announcement" widget's display to "flex" from "block" to resolve a 1 pixel gap.
Fixes issue #412.