### PR TITLE
Accessibility updates

### DIFF
--- a/src/components/common/ToggleMenu.astro
+++ b/src/components/common/ToggleMenu.astro
@@ -10,7 +10,7 @@ const {
 } = Astro.props;
 ---
 
-<button class={className} aria-label={label} data-aw-toggle-menu>
+<button type="button" class={className} aria-label={label} data-aw-toggle-menu>
   <span class="sr-only">{label}</span>
   <slot>
     <span

--- a/src/components/widgets/CallToAction.astro
+++ b/src/components/widgets/CallToAction.astro
@@ -35,7 +35,7 @@ const {
       tagline={tagline}
       classes={{
         container: 'mb-0 md:mb-0',
-        title: 'text-4xl md:text-4xl font-bold leading-tighter tracking-tighter mb-4 font-heading',
+        title: 'text-4xl md:text-4xl font-bold tracking-tighter mb-4 font-heading',
         subtitle: 'text-xl text-muted dark:text-slate-400',
       }}
     />

--- a/src/components/widgets/Content.astro
+++ b/src/components/widgets/Content.astro
@@ -37,7 +37,7 @@ const {
     tagline={tagline}
     classes={{
       container: 'max-w-xl sm:mx-auto lg:max-w-2xl',
-      title: 'text-4xl md:text-5xl font-bold leading-tighter tracking-tighter mb-4 font-heading',
+      title: 'text-4xl md:text-5xl font-bold tracking-tighter mb-4 font-heading',
       subtitle: 'max-w-3xl mx-auto sm:text-center text-xl text-muted dark:text-slate-400',
     }}
   />

--- a/src/components/widgets/Header.astro
+++ b/src/components/widgets/Header.astro
@@ -92,7 +92,7 @@ const currentPath = `/${trimSlash(new URL(Astro.url).pathname)}`;
             <li class={links?.length ? 'dropdown' : ''}>
               {links?.length ? (
                 <>
-                  <button class="hover:text-link dark:hover:text-white px-4 py-3 flex items-center">
+                  <button type="button" class="hover:text-link dark:hover:text-white px-4 py-3 flex items-center">
                     {text}{' '}
                     <Icon name="tabler:chevron-down" class="w-3.5 h-3.5 ml-0.5 rtl:ml-0 rtl:mr-0.5 hidden md:inline" />
                   </button>

--- a/src/components/widgets/Pricing.astro
+++ b/src/components/widgets/Pricing.astro
@@ -48,7 +48,7 @@ const {
                       <span class="text-base leading-6 lowercase text-gray-600 dark:text-slate-400">{period}</span>
                     </div>
                     {items && (
-                      <ul role="list" class="my-8 md:my-10 space-y-2 text-left">
+                      <ul class="my-8 md:my-10 space-y-2 text-left">
                         {items.map(
                           ({ description, icon }) =>
                             description && (


### PR DESCRIPTION
Items Addressed:

* Button Classes did not have explicit types
* Redundant list removed from Pricing list
* redundant `leading-tighter` removed from Headline class function calls
    * This, for some reason, is not removed with `twMerge` 