### PR TITLE
Fix aw-color-text-heading

### DIFF
--- a/src/components/CustomStyles.astro
+++ b/src/components/CustomStyles.astro
@@ -29,7 +29,7 @@ import '@fontsource-variable/inter';
     --aw-color-secondary: rgb(1 84 207);
     --aw-color-accent: rgb(109 40 217);
 
-    --aw-color-text-heading: 'InterVariable';
+    --aw-color-text-heading: rgb(0 0 0);
     --aw-color-text-default: rgb(16 16 16);
     --aw-color-text-muted: rgb(16 16 16 / 66%);
     --aw-color-bg-page: rgb(255 255 255);


### PR DESCRIPTION
The `aw-color-text-heading` variable got wrong after moving variables to the `CustomStyles.astro` component.

This PR fixes it restoring its original value.