### PR TITLE
fix: remove focus border on theme toggle button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@onwidget/astrowind",
-      "version": "1.0.0-beta.36",
+      "version": "1.0.0-beta.37",
       "dependencies": {
         "@astrojs/rss": "^4.0.6",
         "@astrojs/sitemap": "^3.1.5",

--- a/src/components/common/ToggleTheme.astro
+++ b/src/components/common/ToggleTheme.astro
@@ -13,7 +13,7 @@ export interface Props {
 const {
   label = 'Toggle between Dark and Light mode',
   class:
-    className = 'text-muted dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 focus:outline-none focus:ring-4 focus:ring-gray-200 dark:focus:ring-gray-700 rounded-lg text-sm p-2.5 inline-flex items-center',
+    className = 'text-muted dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 focus:outline-none focus:ring-4 focus:ring-gray-200 dark:focus:ring-gray-700 rounded-lg text-sm p-2.5 inline-flex items-center focus:[box-shadow:none]',
   iconClass = 'w-6 h-6',
   iconName = 'tabler:sun',
 } = Astro.props;


### PR DESCRIPTION
Fix the issue that 'focus:outline-none' doesn't work for toggle theme button.

Refer to https://github.com/tailwindlabs/tailwindcss/discussions/12219#discussioncomment-7300181.