### PR TITLE
Update Decap CMS to new npm package & version

### DIFF
--- a/public/decapcms/index.html
+++ b/public/decapcms/index.html
@@ -9,6 +9,6 @@
   </head>
   <body>
     <!-- Include the script that builds the page and powers Decap CMS -->
-    <script src="https://unpkg.com/netlify-cms@^2.0.0/dist/netlify-cms.js"></script>
+    <script src="https://unpkg.com/decap-cms@^3.0.0/dist/decap-cms.js"></script>
   </body>
 </html>


### PR DESCRIPTION
The version of DecapCMS currently used is no longer supported to my knowledge. The new version is available under a new npm package and this PR updates to that version.
As far as I could test things, the new version doesn't break the existing config.