### PR TITLE
Fix the override of the Image objectPosition attribute

### DIFF
--- a/src/utils/images-optimization.ts
+++ b/src/utils/images-optimization.ts
@@ -21,7 +21,7 @@ export interface ImageProps extends Omit<HTMLAttributes<'img'>, 'src'> {
   layout?: Layout;
   widths?: number[] | null;
   aspectRatio?: string | number | null;
-  objectPosition?: string | null;
+  objectPosition?: string;
 }
 
 export type ImagesOptimizer = (

--- a/src/utils/images-optimization.ts
+++ b/src/utils/images-optimization.ts
@@ -21,6 +21,7 @@ export interface ImageProps extends Omit<HTMLAttributes<'img'>, 'src'> {
   layout?: Layout;
   widths?: number[] | null;
   aspectRatio?: string | number | null;
+  objectPosition?: string | null;
 }
 
 export type ImagesOptimizer = (

--- a/src/utils/images-optimization.ts
+++ b/src/utils/images-optimization.ts
@@ -259,7 +259,7 @@ export const unpicOptimizer: ImagesOptimizer = async (image, breakpoints, width,
 /* ** */
 export async function getImagesOptimized(
   image: ImageMetadata | string,
-  { src: _, width, height, sizes, aspectRatio, widths, layout = 'constrained', style = '', ...rest }: ImageProps,
+  { src: _, width, height, sizes, aspectRatio, objectPosition, widths, layout = 'constrained', style = '', ...rest }: ImageProps,
   transform: ImagesOptimizer = () => Promise.resolve([])
 ): Promise<{ src: string; attributes: HTMLAttributes<'img'> }> {
   if (typeof image !== 'string') {
@@ -315,6 +315,7 @@ export async function getImagesOptimized(
         width: width,
         height: height,
         aspectRatio: aspectRatio,
+        objectPosition: objectPosition,
         layout: layout,
       })}${style ?? ''}`,
       ...rest,


### PR DESCRIPTION
### Description

While experimenting with this great template, I noticed that when passing an `objectPosition` attribute to the image in the `Hero2` component, the property is overridden by its default value (`center`) at line 119 in the `images-optimization.ts` file.

### Issue details
- **Issue:** The `objectPosition` prop in not passed to the `getStyle` function, causing it to default to `center` instead of using the provided value.
- **Affected file:** `images-optimization.ts`
- **Affected function:** `getStyle`

### Fix
- Destructured `objectPosition` from the props and passed it the `getStyle` function.

### Impact
- This fix ensures that the `objectPosition` attribute works as expected when used in components like `Hero2`.

I hope this PR is helpful! Let me know if any further adjustments are needed :)