### PR TITLE
Resolve tailwind styles loss in bun environment

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,7 +1,7 @@
 import defaultTheme from 'tailwindcss/defaultTheme';
 import typographyPlugin from '@tailwindcss/typography';
 
-module.exports = {
+export default {
   content: ['./src/**/*.{astro,html,js,jsx,json,md,mdx,svelte,ts,tsx,vue}'],
   theme: {
     extend: {


### PR DESCRIPTION
Change the export syntax in tailwind.config.js from CommonJS to ES modules. This modification fixes the issue of missing Tailwind CSS styles when running the application with bun.

I've made some modifications and tested them successfully on Bun 1.1.29 and Node 18.20.2. While I haven't had the chance to test in other environments, I believe the changes should work well across the board.

In my opinion, these modifications are appropriate, but I'm open to feedback if I've overlooked anything. Please feel free to merge this PR if you find it suitable, or close it if you have any concerns.

For context, I've included the error message I initially encountered below.

```shell
bunx --bun astro dev

...

warn - The `content` option in your Tailwind CSS configuration is missing or empty.
warn - Configure your content sources or your generated CSS will be missing styles.
warn - https://tailwindcss.com/docs/content-configuration
```

Thank you for your consideration!