### PR TITLE
Fixed the default port in which the local dev server starts

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ All commands are run from the root of the project, from a terminal:
 | Command             | Action                                             |
 | :------------------ | :------------------------------------------------- |
 | `npm install`       | Installs dependencies                              |
-| `npm run dev`       | Starts local dev server at `localhost:3000`        |
+| `npm run dev`       | Starts local dev server at `localhost:4321`        |
 | `npm run build`     | Build your production site to `./dist/`            |
 | `npm run preview`   | Preview your build locally, before deploying       |
 | `npm run check`     | Check your project for errors                      |


### PR DESCRIPTION
The Commands section in this README file mentioned that `npm run dev` command starts the local dev server at 
**localhost:3000**. But in reality, the dev starts at port **4321** like all Astro projects do.

This PR fixes that incorrect port number as **localhost:4321**. 

Great work on the template! It is beautiful and flexible.