### PR TITLE
Allow local images to start with src/assets as well as ~/assets

### DIFF
--- a/src/utils/images.ts
+++ b/src/utils/images.ts
@@ -31,17 +31,17 @@ export const findImage = async (
   }
 
   // Absolute paths
-  if (imagePath.startsWith('http://') || imagePath.startsWith('https://') || imagePath.startsWith('/')) {
+  if (imagePath.startsWith('http://') || imagePath.startsWith('https://') || imagePath.startsWith('//')) {
     return imagePath;
   }
 
+  let key = imagePath
   // Relative paths or not "~/assets/"
-  if (!imagePath.startsWith('~/assets/images')) {
-    return imagePath;
+  if (!imagePath.startsWith('~/')) {
+    key = imagePath.replace('~/', '/src/');
   }
 
   const images = await fetchLocalImages();
-  const key = imagePath.replace('~/', '/src/');
 
   return images && typeof images[key] === 'function'
     ? ((await images[key]()) as { default: ImageMetadata })['default']

--- a/src/utils/images.ts
+++ b/src/utils/images.ts
@@ -35,9 +35,9 @@ export const findImage = async (
     return imagePath;
   }
 
-  let key = imagePath
   // Relative paths or not "~/assets/"
-  if (!imagePath.startsWith('~/')) {
+  let key = imagePath;
+  if (imagePath.startsWith('~/')) {
     key = imagePath.replace('~/', '/src/');
   }
 
@@ -84,6 +84,7 @@ export const adaptOpenGraphImages = async (
             typeof resolvedImage !== 'string' && resolvedImage?.width <= defaultWidth
               ? [resolvedImage?.width, resolvedImage?.height]
               : [defaultWidth, defaultHeight];
+          
           _image = (
             await astroAsseetsOptimizer(resolvedImage, [dimensions[0]], dimensions[0], dimensions[1], 'jpg')
           )[0];


### PR DESCRIPTION
I'm trying to use Astrowind on CloudCannon, a CMS for static sites.
When we add images via CloudCannon they are added at the actual path - without the alias (eg. /src/assets/images/).
This would throw an error that it cannot parse the image Url.

This refactor allows either image path to work.