### PR TITLE
Fix zero Timeline items bug and don't render empty ItemGrid divs

### DIFF
--- a/src/components/ui/ItemGrid.astro
+++ b/src/components/ui/ItemGrid.astro
@@ -17,7 +17,7 @@ const {
 ---
 
 {
-  items && (
+  items && items.length > 0 && (
     <div
       class={twMerge(
         `grid mx-auto gap-8 md:gap-y-12 ${

--- a/src/components/ui/ItemGrid2.astro
+++ b/src/components/ui/ItemGrid2.astro
@@ -17,7 +17,7 @@ const {
 ---
 
 {
-  items && (
+  items && items.length > 0 && (
     <div
       class={twMerge(
         `grid gap-8 gap-x-12 sm:gap-y-8 ${

--- a/src/components/ui/Timeline.astro
+++ b/src/components/ui/Timeline.astro
@@ -21,7 +21,7 @@ const {
 ---
 
 {
-  items && items.length && (
+  items && items.length > 0 && (
     <div class={containerClass}>
       {items.map(({ title, description, icon, classes: itemClasses = {} }, index = 0) => (
         <div


### PR DESCRIPTION
This PR will fix a bug where `<Timeline items={[]} />` will render a `0` instead of nothing, and also fix the annoyance of empty divs being rendered when using an empty `ItemGrid`/`ItemGrid2`, for example in a `<Content ... />` widget without any `items` set.