### PR TITLE
Fix imports from '../ui/' to '~/components/ui/'

### DIFF
--- a/src/components/widgets/BlogLatestPosts.astro
+++ b/src/components/widgets/BlogLatestPosts.astro
@@ -7,7 +7,7 @@ import { getBlogPermalink } from '~/utils/permalinks';
 import { findLatestPosts } from '~/utils/blog';
 import WidgetWrapper from '~/components/ui/WidgetWrapper.astro';
 import type { Widget } from '~/types';
-import Button from '../ui/Button.astro';
+import Button from '~/components/ui/Button.astro';
 
 export interface Props extends Widget {
   title?: string;

--- a/src/components/widgets/CallToAction.astro
+++ b/src/components/widgets/CallToAction.astro
@@ -1,5 +1,5 @@
 ---
-import WidgetWrapper from '../ui/WidgetWrapper.astro';
+import WidgetWrapper from '~/components/ui/WidgetWrapper.astro';
 import type { CallToAction, Widget } from '~/types';
 import Headline from '~/components/ui/Headline.astro';
 import Button from '~/components/ui/Button.astro';

--- a/src/components/widgets/Content.astro
+++ b/src/components/widgets/Content.astro
@@ -1,10 +1,10 @@
 ---
 import type { Content as Props } from '~/types';
-import Headline from '../ui/Headline.astro';
-import WidgetWrapper from '../ui/WidgetWrapper.astro';
+import Headline from '~/components/ui/Headline.astro';
+import WidgetWrapper from '~/components/ui/WidgetWrapper.astro';
 import Image from '~/components/common/Image.astro';
 import Button from '~/components/ui/Button.astro';
-import ItemGrid from '../ui/ItemGrid.astro';
+import ItemGrid from '~/components/ui/ItemGrid.astro';
 
 const {
   title = await Astro.slots.render('title'),

--- a/src/components/widgets/Stats.astro
+++ b/src/components/widgets/Stats.astro
@@ -1,7 +1,7 @@
 ---
 import type { Stats as Props } from '~/types';
-import WidgetWrapper from '../ui/WidgetWrapper.astro';
-import Headline from '../ui/Headline.astro';
+import WidgetWrapper from '~/components/ui/WidgetWrapper.astro';
+import Headline from '~/components/ui/Headline.astro';
 import { Icon } from 'astro-icon/components';
 
 const {


### PR DESCRIPTION
Hello there.

Just changing the import to use the custom `~` path map instead of a relative path to import UI components. It now appears to be in line with the way the neighboring files import UI components.