### PR TITLE
Implement properties for `Note` component

### DIFF
--- a/src/components/widgets/Note.astro
+++ b/src/components/widgets/Note.astro
@@ -1,11 +1,23 @@
 ---
 import { Icon } from 'astro-icon/components';
+
+export interface Props {
+  icon?: string;
+  title?: string;
+  description?: string;
+}
+
+const {
+  icon = 'tabler:info-square',
+  title = await Astro.slots.render('title'),
+  description = await Astro.slots.render('description'),
+} = Astro.props;
 ---
 
 <section class="bg-blue-50 dark:bg-slate-800 not-prose">
   <div class="max-w-6xl mx-auto px-4 sm:px-6 py-4 text-md text-center font-medium">
-    <span class="font-bold">
-      <Icon name="tabler:info-square" class="w-5 h-5 inline-block align-text-bottom" /> Philosophy:</span
-    > Simplicity, Best Practices and High Performance
+    <Icon name={icon} class="w-5 h-5 inline-block align-text-bottom" />
+    <span class="font-bold" set:html={title} />
+    <Fragment set:html={description} />
   </div>
 </section>

--- a/src/components/widgets/Note.astro
+++ b/src/components/widgets/Note.astro
@@ -16,7 +16,7 @@ const {
 
 <section class="bg-blue-50 dark:bg-slate-800 not-prose">
   <div class="max-w-6xl mx-auto px-4 sm:px-6 py-4 text-md text-center font-medium">
-    <Icon name={icon} class="w-5 h-5 inline-block align-text-bottom" />
+    <Icon name={icon} class="w-5 h-5 inline-block align-text-bottom font-bold" />
     <span class="font-bold" set:html={title} />
     <Fragment set:html={description} />
   </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -52,7 +52,7 @@ const metadata = {
 
   <!-- Note Widget ******************* -->
 
-  <Note />
+  <Note title="Philosophy:" description="Simplicity, Best Practices and High Performance" />
 
   <!-- Features Widget *************** -->
 


### PR DESCRIPTION
The `Note` component was fully static.

I've added `title?`, `description?` and `icon?` properties.

I've NOT added a definition for `Props` to `src/types.d.ts` as is usually the case with the components in `src/components/widgets/`: I found two components that didn't: `src/components/widgets/HeroText.astro` and `src/components/widgets/Stats.astro`; with this PR the `Note` component will be in the same state as those component.

In any case this PR successfully allows the use of attributes for the `Note` component.