### PR TITLE
Use `Item` type definition for `items` property of `Steps` type

### DIFF
--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -262,12 +262,7 @@ export interface Faqs extends Omit<Headline, 'classes'>, Widget {
 }
 
 export interface Steps extends Omit<Headline, 'classes'>, Widget {
-  items: Array<{
-    title: string;
-    description?: string;
-    icon?: string;
-    classes?: Record<string, string>;
-  }>;
+  items: Array<Item>;
   callToAction?: string | CallToAction;
   image?: string | Image;
   isReversed?: boolean;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -262,7 +262,7 @@ export interface Faqs extends Omit<Headline, 'classes'>, Widget {
 }
 
 export interface Steps extends Omit<Headline, 'classes'>, Widget {
-  items: Array<Item>;
+  items?: Array<Item>;
   callToAction?: string | CallToAction;
   image?: string | Image;
   isReversed?: boolean;


### PR DESCRIPTION
The `Steps` interface definition for the `items` property uses this custom object:

```typescript
items: Array<{
  title: string;
  description?: string;
  icon?: string;
  classes?: Record<string, string>;
}>;
```

The definition of `Item` is:
```typescript
export interface Item {
  title?: string;
  description?: string;
  icon?: string;
  classes?: Record<string, string>;
  callToAction?: CallToAction;
  image?: Image;
}
```

Aside from `title` being optional in `Item` and not in the custom object, the objects fit perfectly. By looking at other components it appears that the `Item` type is meant to be used like this.