### PR TITLE
Remove extraneous references to non-existing `highlight` css class

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -23,7 +23,7 @@ const metadata = {
   >
     <Fragment slot="title">
       Elevate your online presence with our <br />
-      <span class="text-accent dark:text-white highlight"> Beautiful Website Templates</span>
+      <span class="text-accent dark:text-white"> Beautiful Website Templates</span>
     </Fragment>
 
     <Fragment slot="subtitle">

--- a/src/pages/homes/mobile-app.astro
+++ b/src/pages/homes/mobile-app.astro
@@ -56,7 +56,7 @@ const metadata = {
     }}
   >
     <Fragment slot="title">
-      <span class="text-accent dark:text-white highlight">AstroWind App</span>: <br /> professional websites <span
+      <span class="text-accent dark:text-white">AstroWind App</span>: <br /> professional websites <span
         class="hidden xl:inline">made easy</span
       >
     </Fragment>

--- a/src/pages/homes/saas.astro
+++ b/src/pages/homes/saas.astro
@@ -51,7 +51,7 @@ const metadata = {
     }}
   >
     <Fragment slot="title">
-      Simplify web design with Astrowind: <br /> your ultimate <span class="text-accent dark:text-white highlight"
+      Simplify web design with Astrowind: <br /> your ultimate <span class="text-accent dark:text-white"
         >SaaS</span
       > companion<br />
     </Fragment>

--- a/src/pages/homes/startup.astro
+++ b/src/pages/homes/startup.astro
@@ -36,7 +36,7 @@ const metadata = {
   >
     <Fragment slot="title">
       Improve <span class="hidden sm:inline">the online presence of</span> your <span
-        class="text-accent dark:text-white highlight">Startup</span
+        class="text-accent dark:text-white">Startup</span
       > with Astrowind templates
     </Fragment>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -36,7 +36,7 @@ const metadata = {
   >
     <Fragment slot="title">
       Free template for <span class="hidden xl:inline">creating websites with</span>
-      <span class="text-accent dark:text-white highlight"> Astro 5.0</span> + Tailwind CSS
+      <span class="text-accent dark:text-white"> Astro 5.0</span> + Tailwind CSS
     </Fragment>
 
     <Fragment slot="subtitle">


### PR DESCRIPTION
I was making some tailwind alias classes and got an error about a non-existing `hightlight` class.

I checked: it's not part of Tailwind and there isn't a definition for it anywhere in the project's scope.

Correct me if I'm wrong but I believe these can be safely removed.