### PR TITLE
chore(ci): resolve Prettier check failures in README, saas, and images.ts

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ We're embarking on an exciting journey with **AstroWind 2.0**, and we want you t
 
 <br>
 
-
 ## TL;DR
 
 ```shell

--- a/src/pages/homes/saas.astro
+++ b/src/pages/homes/saas.astro
@@ -51,9 +51,8 @@ const metadata = {
     }}
   >
     <Fragment slot="title">
-      Simplify web design with Astrowind: <br /> your ultimate <span class="text-accent dark:text-white"
-        >SaaS</span
-      > companion<br />
+      Simplify web design with Astrowind: <br /> your ultimate <span class="text-accent dark:text-white">SaaS</span> companion<br
+      />
     </Fragment>
 
     <Fragment slot="subtitle">

--- a/src/utils/images.ts
+++ b/src/utils/images.ts
@@ -84,9 +84,7 @@ export const adaptOpenGraphImages = async (
             typeof resolvedImage !== 'string' && resolvedImage?.width <= defaultWidth
               ? [resolvedImage?.width, resolvedImage?.height]
               : [defaultWidth, defaultHeight];
-          _image = (
-            await astroAssetsOptimizer(resolvedImage, [dimensions[0]], dimensions[0], dimensions[1], 'jpg')
-          )[0];
+          _image = (await astroAssetsOptimizer(resolvedImage, [dimensions[0]], dimensions[0], dimensions[1], 'jpg'))[0];
         }
 
         if (typeof _image === 'object') {


### PR DESCRIPTION
## Summary

Resolves failing `check` job in GitHub Actions caused by Prettier formatting mismatches.

Applied `prettier --write` to:

- `README.md`
- `src/pages/homes/saas.astro`
- `src/utils/images.ts`

No functional changes. Style-only fix.

## CI Outcome

- ✅ `npm run check` passes
- ✅ All GitHub Actions complete successfully