### PR TITLE
fix hint on images.ts

### DIFF
--- a/src/utils/images.ts
+++ b/src/utils/images.ts
@@ -71,7 +71,7 @@ export const adaptOpenGraphImages = async (
           };
         }
 
-        let _image;
+        let _image: { src: string; width: number; } | undefined;
 
         if (
           typeof resolvedImage === 'string' &&


### PR DESCRIPTION
fix hint on images.ts when running `npm run check`

```
src/utils/images.ts:74:13 - warning ts(7043): Variable '_image' implicitly has an 'any' type, but a better type may be inferred from usage.
```