### PR TITLE
Remove redundant assignment in `Metadata.astro`

### DIFF
--- a/src/components/common/Metadata.astro
+++ b/src/components/common/Metadata.astro
@@ -55,7 +55,6 @@ const seoProps: AstroSeoProps = merge(
   {
     title: title,
     titleTemplate: ignoreTitleTemplate ? '%s' : undefined,
-    canonical: canonical,
     noindex: typeof robots?.index !== 'undefined' ? !robots.index : undefined,
     nofollow: typeof robots?.follow !== 'undefined' ? !robots.follow : undefined,
     description: description,


### PR DESCRIPTION
In `src/components/common/Metadata.astro` the `seoProps` object (created using lodash's `merge()`) has a redundant definition for its `canonical` property. It is already defined on line 20.