### PR TITLE
Add missing apostrophe in 404 page

### DIFF
--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -15,7 +15,7 @@ const title = `Error 404`;
         </h2>
         <p class="text-3xl font-semibold md:text-3xl">Sorry, we couldn't find this page.</p>
         <p class="mt-4 mb-8 text-lg text-muted dark:text-slate-400">
-          But dont worry, you can find plenty of other things on our homepage.
+          But don't worry, you can find plenty of other things on our homepage.
         </p>
         <a rel="noopener noreferrer" href={getHomePermalink()} class="btn ml-4">Back to homepage</a>
       </div>


### PR DESCRIPTION
This PR fixes a grammar problem in the 404.astro file. An apostrophe was missing, but this PR fixes it.