### PR TITLE
Fix blog posts location in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,11 +104,15 @@ Inside **AstroWind** template, you'll see the following folders and files:
 │   │   ├── Favicons.astro
 │   │   └── Logo.astro
 │   ├── content/
+│   │   ├── config.ts
+│   ├── data/
 │   │   ├── post/
-│   │   │   ├── post-slug-1.md
-│   │   │   ├── post-slug-2.mdx
-│   │   │   └── ...
-│   │   └-- config.ts
+│   │   │   ├── astrowind-template-in-depth.mdx
+│   │   │   └── get-started-website-with-astro-tailwind-css.md
+│   │   │   └── how-to-customize-astrowind-to-your-brand.md
+│   │   │   └── landing.md
+│   │   │   └── markdown-elements-demo-post.mdx
+│   │   │   └── useful-resources-to-create-websites.md
 │   ├── layouts/
 │   │   ├── Layout.astro
 │   │   ├── MarkdownLayout.astro


### PR DESCRIPTION
### What this PR does

Fixes the README documentation regarding blog post location.

### Why

The README currently points to an incorrect directory.
In the actual project structure, blog posts live in `src/data/post`
and are loaded via Astro Content Collections.

This PR aligns the documentation with the real folder structure.